### PR TITLE
Update forgot password and reset password routes

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     DATABASE_URL: Optional[str] = None
     sender_email: str = "fill sender_email .env.dev"
     sender_password:str = "fill sender_password .env.dev"
+    email_template:str="fill email_template .env.dev"
     # JWT
     secret_key: str = "secret"
     algorithm: str = "HS256"

--- a/models/employee.py
+++ b/models/employee.py
@@ -227,7 +227,7 @@ class Employee(Document):
             "example": {
                 "employee_id": "EMP0001",
                 "name": "John Doe",
-                "email": "EMP0001@gmail.com",
+                "email": "emp0001@gmail.com",
                 "password": "password",
                 "role": "employee",
                 "manager_id": "EMP1001",


### PR DESCRIPTION
Made email input case-insensitive for password reset requests.

Updated the reset link to redirect to the frontend server using a configurable template from .env.dev.

Implemented token expiration for enhanced security.

Limited the number of forgot password requests to prevent abuse.

Merged the latest changes from the main branch into forgotpass for sync.